### PR TITLE
Fix building on Win32

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,6 +65,12 @@ if (NINTENDO_SWITCH)
     set(BUILD_SHARED_LIBS OFF)
 endif()
 
+if (WIN32)
+    # Using UNICODE with NFD currently creates random UTF-8 folders on the
+    # filesystem.
+    add_definitions(-DFTG_IGNORE_UNICODE)
+endif()
+
 if (PLATFORM_LIBRETRO)
     if (SWITCH)
         set(BUILD_SHARED_LIBS OFF)

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ you will need to install the following packages.
 for linux, use your package manager. on windows, use vcpkg.
 
 ```cmake
-cmake -B build -PLATFORM_SDL2=ON -DCMAKE_BUILD_TYPE=Release
+cmake -B build -DPLATFORM_SDL2=ON -DCMAKE_BUILD_TYPE=Release
 cmake --build build -j
 ```
 

--- a/src/third-party/nativefiledialog/CMakeLists.txt
+++ b/src/third-party/nativefiledialog/CMakeLists.txt
@@ -31,7 +31,7 @@ elseif (${CMAKE_SYSTEM_NAME} STREQUAL "Darwin")
 
 elseif (${CMAKE_SYSTEM_NAME} STREQUAL "Windows")
     project(unofficial-nativefiledialog LANGUAGES C)
-    add_library(unofficial-nativefiledialog nfd_win.m)
+    add_library(unofficial-nativefiledialog nfd_win.c)
     add_library(unofficial::nativefiledialog::nfd ALIAS ${PROJECT_NAME})
     target_include_directories(unofficial-nativefiledialog PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
     set(HAS_NFD ON PARENT_SCOPE)

--- a/src/third-party/nativefiledialog/nfd_win.c
+++ b/src/third-party/nativefiledialog/nfd_win.c
@@ -13,9 +13,10 @@
 #    define _CRT_SECURE_NO_WARNINGS
 #endif
 
-#include <stdlib.h>
 #include <assert.h>
+#include <stdlib.h>
 #include <string.h>
+#include <windows.h>
 
 #include "nfd.h"
 


### PR DESCRIPTION
Hi!

I made a few changes to fix building TotalGB on Windows in a MinGW environment (w64devkit). With these changes, compiling with SDL2 support succeeds and I'm able to start playing a game. Tested on Windows 10 only.

Thanks.